### PR TITLE
Use `std::numeric_limits` in C++

### DIFF
--- a/ReactAndroid/src/main/jni/react/JSCExecutor.cpp
+++ b/ReactAndroid/src/main/jni/react/JSCExecutor.cpp
@@ -340,7 +340,7 @@ JSValueRef JSCExecutor::nativeRequire(
   }
 
   double moduleId = JSValueToNumber(ctx, arguments[0], exception);
-  if (moduleId <= (double) UINT32_MAX && moduleId >= 0.0) {
+  if (moduleId <= (double) std::numeric_limits<uint32_t>::max() && moduleId >= 0.0) {
     try {
       executor->loadModule(moduleId);
     } catch (JSModulesUnbundle::ModuleNotFound&) {


### PR DESCRIPTION
Instead of using `UINT32_MAX` in C++ code, use `std::numeric_limits<uint32_t>::max()`. The `UINT32_MAX` macro is not available in all compilation setups
